### PR TITLE
ci: build against the Gershwin stack via gershwin-developer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,139 @@
+name: Build Gershwin Terminal
+
+# Build gershwin-terminal against the real Gershwin stack by reusing
+# gershwin-developer: build the core libraries once ("make corelibs"), then
+# build the checkout under test ("make terminal"). The terminal sources are
+# provided by this repo's checkout via a symlink, and SKIP_REPOS keeps
+# Checkout.sh from cloning gershwin-terminal itself or any sibling apps that
+# are not needed to build the core libraries.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  # Repos Checkout.sh should NOT clone:
+  #   - gershwin-terminal       -> provided by this repo's checkout (symlinked)
+  #   - the other sibling apps  -> not needed to build corelibs + terminal
+  # Everything else (libdispatch, libobjc2, tools-make, libs-base/gui/back,
+  # gershwin-system, gershwin-components, gershwin-assets) is still cloned.
+  SKIP_REPOS: >-
+    gershwin-terminal
+    gershwin-workspace
+    gershwin-systempreferences
+    gershwin-eau-theme
+    gershwin-textedit
+    gershwin-windowmanager
+
+jobs:
+  build-freebsd-14-amd64:
+    name: FreeBSD x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: gershwin-terminal
+
+      - name: Build terminal inside FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "14.3"
+          usesh: true
+          sync: rsync
+          copyback: false
+          cpu: 2
+          mem: 4096
+          prepare: |
+            pkg update
+            pkg install -y git
+          run: |
+            set -e
+            BASE="$(pwd)"
+            git clone --depth 1 https://github.com/gershwin-desktop/gershwin-developer.git
+            cd "$BASE/gershwin-developer"
+            ./Library/Scripts/Bootstrap.sh
+            SKIP_REPOS="${{ env.SKIP_REPOS }}" ./Library/Scripts/Checkout.sh
+            ln -sfn "$BASE/gershwin-terminal" Library/Sources/gershwin-terminal
+            make corelibs
+            make terminal
+
+  build-archlinux-x86_64:
+    name: Arch x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    container:
+      image: archlinux:latest
+    steps:
+      - name: Install git
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm base-devel git
+
+      - uses: actions/checkout@v4
+        with:
+          path: gershwin-terminal
+
+      - name: Clone gershwin-developer
+        run: git clone --depth 1 https://github.com/gershwin-desktop/gershwin-developer.git
+
+      - name: Bootstrap
+        working-directory: gershwin-developer
+        run: ./Library/Scripts/Bootstrap.sh
+
+      - name: Checkout sources (skip terminal and sibling apps)
+        working-directory: gershwin-developer
+        run: ./Library/Scripts/Checkout.sh
+
+      - name: Link terminal source under test
+        working-directory: gershwin-developer
+        run: ln -sfn "$GITHUB_WORKSPACE/gershwin-terminal" Library/Sources/gershwin-terminal
+
+      - name: Build core libraries
+        working-directory: gershwin-developer
+        run: make corelibs
+
+      - name: Build terminal
+        working-directory: gershwin-developer
+        run: make terminal
+
+  build-debian-x86_64:
+    name: Debian x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    container:
+      image: debian:bookworm
+    steps:
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get -y install git
+
+      - uses: actions/checkout@v4
+        with:
+          path: gershwin-terminal
+
+      - name: Clone gershwin-developer
+        run: git clone --depth 1 https://github.com/gershwin-desktop/gershwin-developer.git
+
+      - name: Bootstrap
+        working-directory: gershwin-developer
+        run: ./Library/Scripts/Bootstrap.sh
+
+      - name: Checkout sources (skip terminal and sibling apps)
+        working-directory: gershwin-developer
+        run: ./Library/Scripts/Checkout.sh
+
+      - name: Link terminal source under test
+        working-directory: gershwin-developer
+        run: ln -sfn "$GITHUB_WORKSPACE/gershwin-terminal" Library/Sources/gershwin-terminal
+
+      - name: Build core libraries
+        working-directory: gershwin-developer
+        run: make corelibs
+
+      - name: Build terminal
+        working-directory: gershwin-developer
+        run: make terminal


### PR DESCRIPTION
## What

Adds CI that builds gershwin-terminal against the **real, pinned Gershwin stack** on FreeBSD, Arch and Debian, reusing gershwin-developer's granular build targets. Mirrors the workflow added to gershwin-workspace (#97).

## How it works

Each job:
1. Checks out this repo (the code under test) to `gershwin-terminal/`.
2. Clones `gershwin-developer`.
3. `Bootstrap.sh` to install OS packages.
4. `Checkout.sh` with `SKIP_REPOS` so it clones the dependency stack but **not** gershwin-terminal (provided here) or the sibling apps that aren't needed.
5. Symlinks this checkout into `Library/Sources/gershwin-terminal`.
6. `make corelibs` (build the core libraries once), then `make terminal`.

`SKIP_REPOS` skips: `gershwin-terminal` (symlinked in) + `workspace`, `systempreferences`, `eau-theme`, `textedit`, `windowmanager`. Still cloned (needed by corelibs): libdispatch, libobjc2, tools-make, libs-base/gui/back, gershwin-system, gershwin-components (the `plistupdate` hook), gershwin-assets.

Build + install only — no packaging, no artifact upload.

## Dependency

Uses gershwin-developer's `corelibs`/`terminal` targets and `SKIP_REPOS`, both already on gershwin-developer `main` (gershwin-developer#39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)