### PR TITLE
Link -liconv on OpenBSD

### DIFF
--- a/GNUmakefile.preamble
+++ b/GNUmakefile.preamble
@@ -28,3 +28,10 @@ ADDITIONAL_LDFLAGS += -lutil -lX11
 ifeq ($(findstring freebsd,$(GNUSTEP_TARGET_OS)),freebsd)
 ADDITIONAL_LDFLAGS += -liconv
 endif
+
+# On OpenBSD, iconv is provided by GNU libiconv (its header rewrites iconv_* to
+# libiconv_*), so the iconv symbols live in libiconv rather than libc and must
+# be linked explicitly.
+ifeq ($(findstring openbsd,$(GNUSTEP_TARGET_OS)),openbsd)
+ADDITIONAL_LDFLAGS += -liconv
+endif


### PR DESCRIPTION
## Problem

On OpenBSD the Terminal app fails to link:

```
ld: error: undefined symbol: libiconv
ld: error: undefined symbol: libiconv_open
ld: error: undefined symbol: libiconv_close
  referenced by TerminalParser_Linux.m
```

`TerminalParser_Linux.m` uses iconv. On OpenBSD, iconv is provided by **GNU libiconv** (pulled in via packages), whose `<iconv.h>` rewrites `iconv_open`/`iconv`/`iconv_close` to `libiconv_open`/`libiconv`/`libiconv_close`. Those symbols live in `libiconv`, not libc, so the link fails unless `-liconv` is passed. The preamble only added `-liconv` for FreeBSD.

## Fix

Add an OpenBSD branch to `GNUmakefile.preamble` that appends `-liconv`, mirroring the existing FreeBSD branch. The block is gated on `GNUSTEP_TARGET_OS`, so **Linux/FreeBSD builds are unchanged** — the existing FreeBSD/Arch/Debian CI here should stay green.

## Context

gershwin-developer#33 tried to work around this in the build script by *stripping* `-liconv` on OpenBSD via `sed` — the wrong direction, which is why it still failed to link. Fixing it here (in the preamble) is the proper fix referenced by the existing `TODO: Port this fix to GNUmakefile.preamble properly` comment, and lets gershwin-developer drop that workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)