### PR TITLE
ci: add OpenBSD build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,3 +137,34 @@ jobs:
       - name: Build terminal
         working-directory: gershwin-developer
         run: make terminal
+
+  build-openbsd-78-amd64:
+    name: OpenBSD x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: gershwin-terminal
+
+      - name: Build terminal inside OpenBSD VM
+        uses: vmactions/openbsd-vm@v1
+        with:
+          release: "7.8"
+          usesh: true
+          sync: rsync
+          copyback: false
+          cpu: 2
+          mem: 4096
+          prepare: |
+            pkg_add -I git
+          run: |
+            set -e
+            BASE="$(pwd)"
+            git clone --depth 1 https://github.com/gershwin-desktop/gershwin-developer.git
+            cd "$BASE/gershwin-developer"
+            ./Library/Scripts/Bootstrap.sh
+            SKIP_REPOS="${{ env.SKIP_REPOS }}" ./Library/Scripts/Checkout.sh
+            ln -sfn "$BASE/gershwin-terminal" Library/Sources/gershwin-terminal
+            make corelibs
+            make terminal


### PR DESCRIPTION
## What

Adds an **OpenBSD 7.8** job to the terminal CI, mirroring the FreeBSD/Arch/Debian jobs: clone gershwin-developer → `Bootstrap` → `Checkout` (with `SKIP_REPOS`) → symlink this checkout into `Library/Sources/gershwin-terminal` → `make corelibs` → `make terminal`.

Uses `vmactions/openbsd-vm` (release 7.8). **Build + install only — no packaging.**

## Why now

gershwin-developer's OpenBSD support is on `main`, including this repo's `-liconv`-on-OpenBSD fix, so corelibs + terminal build on OpenBSD.

Note: emulated VM building the full core stack — expect it to take a while (timeout 240m), like the FreeBSD job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)